### PR TITLE
Legend Placement on plot_state_steps

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -172,7 +172,7 @@ function plot_state_steps(state_steps; kwargs...)
     xlabel = "s"
     ylabel = "prob"
     title = "Spin Trajectories"
-    legend = :right
+    legend = :topleft
     plt = Plots.plot(ss, plotted_states'; title=title, label=labels, xlabel=xlabel, ylabel=ylabel, legend=legend, kwargs...)
     return plt
 end


### PR DESCRIPTION
I think this is a good default as the system size goes up the left most values will be pushed to zero (making room for the legend) and the viewer is most interested in the distribution on the right side of the plot.