### PR TITLE
Add filtering for most plotting functions

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -11,3 +11,23 @@ function spin_hamming_distance(spin_1, spin_2)
     end
     return hamming_dist
 end
+
+function _get_states(ising_model, energy_levels; n = 0)
+    states = nothing
+    if (ising_model == nothing && n == 0)
+        error("both ising model and n were not specified, could not compute states")
+    elseif ising_model == nothing && energy_levels != 0
+        error("must provide ising model if energy_levels != 0")
+    elseif ising_model != nothing && energy_levels != 0
+        energies = _QA.compute_ising_energy_levels(ising_model)
+        energy_levels = (energy_levels == 0) ? length(energies) : energy_levels
+
+        states = sort(collect(foldl(union, [energies[i].states for i = 1:energy_levels])))
+    else
+        if n == 0
+            n = _QA._check_ising_model_ids(ising_model)
+        end
+        states = 0:2^n-1
+    end
+    return states
+end

--- a/src/base.jl
+++ b/src/base.jl
@@ -14,13 +14,15 @@ end
 
 function _get_states(ising_model, energy_levels; n = 0)
     states = nothing
-    if (ising_model == nothing && n == 0)
+    if energy_levels < 0
+        error("cannot have a negative number of energy levels")
+    elseif (ising_model == nothing && n == 0)
         error("both ising model and n were not specified, could not compute states")
     elseif ising_model == nothing && energy_levels != 0
         error("must provide ising model if energy_levels != 0")
     elseif ising_model != nothing && energy_levels != 0
         energies = _QA.compute_ising_energy_levels(ising_model)
-        energy_levels = (energy_levels == 0) ? length(energies) : energy_levels
+        energy_levels = min(energy_levels, length(energies))
 
         states = sort(collect(foldl(union, [energies[i].states for i = 1:energy_levels])))
     else

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -13,7 +13,7 @@ end
 function to plot the states present in a density matrix output by QuantumAnnealing.simulate
 kwargs are for Plots.bar
 """
-function plot_states(ρ;order=:numeric,spin_comp=ones(Int(log2(size(ρ)[1]))),num_states=16, kwargs...)
+function plot_states(ρ;order=:numeric,spin_comp=ones(Int(log2(size(ρ)[1]))),num_states=16, ising_model=nothing, energy_levels=0, kwargs...)
     state_probs = _QA.z_measure_probabilities(ρ)
     n = Int(log2(length(state_probs)))
     state_spin_vecs = map((x) -> _QA.int2spin(x,pad=n), 0:2^n-1)
@@ -34,6 +34,19 @@ function plot_states(ρ;order=:numeric,spin_comp=ones(Int(log2(size(ρ)[1]))),nu
     else
         error("order must be either :numeric or :hamming or :prob")
     end
+
+    kept_states = 0:2^n-1
+    if energy_levels != 0
+        if ising_model == nothing
+            error("must provide ising_model if energy levels are specified")
+        else
+            energies = _QA.compute_ising_energy_levels(ising_model)
+            kept_states = foldl(union, [energies[i].states for i = 1:energy_levels])
+        end
+    end
+
+    filter_function = (x) -> _QA.spin2int(x.spin_vec) in kept_states
+    states = filter(filter_function, states)
 
     states = sort(states, by=sortby)
     probs = [states[i].prob for i = 1:length(states)]
@@ -163,15 +176,29 @@ end
 function to plot the state steps, generated from calling simulate(..., state_steps=[]).  This
 is used to see instantaneous measurement values throughout the anneal.  kwargs are for Plots.plot
 """
-function plot_state_steps(state_steps; kwargs...)
+function plot_state_steps(state_steps; ising_model=nothing, energy_levels=0, kwargs...)
     n = Int(log2(size(state_steps[1])[1]))
     ss = range(0,1,length=length(state_steps))
 
     state_probs = map(x -> [real(x[i,i]) for i = 1:2^n], state_steps)
     plotted_states = foldl(hcat,state_probs)
 
+    kept_states = 0:2^n-1
+    kept_indices = 1:2^n
+    if energy_levels != 0
+        if ising_model == nothing
+            error("must provide ising_model if energy levels are specified")
+        else
+            energies = _QA.compute_ising_energy_levels(ising_model)
+            kept_states = sort(collect(foldl(union, [energies[i].states for i = 1:energy_levels])))
+            kept_indices = kept_states .+ 1
+        end
+    end
+
     int2braket(i) = _QA.spin2braket(_QA.binary2spin(_QA.int2binary(i,pad=n)))
-    labels = map(int2braket, reshape(0:2^n-1,1,:))
+    labels = map(int2braket, reshape(kept_states,1,:))
+
+    plotted_states = plotted_states[kept_indices,:]
 
     xlabel = "s"
     ylabel = "prob"
@@ -181,7 +208,7 @@ function plot_state_steps(state_steps; kwargs...)
     return plt
 end
 
-function plot_varied_time_simulations(ising_model::Dict, annealing_schedule::_QA.AnnealingSchedule, time_range::Tuple; num_points=50, xscale=:identity, kwargs...)
+function plot_varied_time_simulations(ising_model::Dict, annealing_schedule::_QA.AnnealingSchedule, time_range::Tuple; num_points=50, xscale=:identity, energy_levels = 0, kwargs...)
     n = _QA._check_ising_model_ids(ising_model)
     plotted_values = zeros(num_points, 2^n)
     annealing_times = nothing
@@ -200,12 +227,25 @@ function plot_varied_time_simulations(ising_model::Dict, annealing_schedule::_QA
         plotted_values[i,:] = probs
     end
 
+    energies = _QA.compute_ising_energy_levels(ising_model)
+    kept_states = nothing
+    if energy_levels in 1:length(energies)
+        kept_states = sort(collect(foldl(union, [energies[i].states for i = 1:energy_levels])))
+    elseif energy_levels == 0
+        kept_states = [0:2^n-1]
+    else
+        error("Invalid number of energy levels specified")
+    end
+
+    kept_indices = kept_states .+ 1
+    plotted_values = plotted_values[:,kept_indices]
+
     title = "Time Sweep Probabilities"
     xlabel = "annealing time"
     ylabel = "prob"
 
     int2braket(i) = _QA.spin2braket(_QA.binary2spin(_QA.int2binary(i,pad=n)))
-    labels = map(int2braket, reshape(0:2^n-1,1,:))
+    labels = map(int2braket, reshape(kept_states,1,:))
     legend = :right
     plt = Plots.plot(annealing_times, plotted_values; title=title, xlabel=xlabel, ylabel=ylabel, label = labels, legend=legend, xscale=xscale, kwargs...)
     return plt

--- a/test/base.jl
+++ b/test/base.jl
@@ -9,8 +9,7 @@
         @test spin_hamming_distance([1, 1, 1], [-1, 1, -1]) == 2
         @test spin_hamming_distance([1, 1, 1], [-1, -1, 1]) == 2
         @test spin_hamming_distance([1, 1, 1], [-1, -1, -1]) == 3
-
-        @test spin_hamming_distance([-1, -1, -1], [1, 1, 1]) == 3
+@test spin_hamming_distance([-1, -1, -1], [1, 1, 1]) == 3
         @test spin_hamming_distance([-1, -1, -1], [-1, 1, 1]) == 2
         @test spin_hamming_distance([-1, -1, -1], [1, -1, 1]) == 2
         @test spin_hamming_distance([-1, -1, -1], [1, 1, -1]) == 2
@@ -20,4 +19,50 @@
         @test spin_hamming_distance([-1, -1, -1], [-1, -1, -1]) == 0
     end
 
+end
+
+@testset "get_states functionality" begin
+    ising_model = nothing; energy_levels = 0; n = 0
+    try
+        states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+        @test false
+    catch
+        @test true
+    end
+
+    ising_model = nothing; energy_levels = 0; n = 2
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [0, 1, 2, 3]
+
+    ising_model = nothing; energy_levels = 1; n = 0
+    try
+        states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+        @test false
+    catch
+        @test true
+    end
+
+    ising_model = nothing; energy_levels = 1; n = 2
+    try
+        states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+        @test false
+    catch
+        @test true
+    end
+
+    ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 0; n = 0
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [0, 1, 2, 3]
+
+    ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 0; n = 2
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [0, 1, 2, 3]
+
+    ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 1; n = 0
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [3]
+
+    ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 1; n = 2
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [3]
 end

--- a/test/base.jl
+++ b/test/base.jl
@@ -65,4 +65,17 @@ end
     ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 1; n = 2
     states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
     @test states == [3]
+
+
+    ising_model = nothing; energy_levels = -1; n = 2
+    try
+        states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+        @test false
+    catch
+        @test true
+    end
+
+    ising_model = Dict((1,) => 1, (2,) => 1); energy_levels = 10; n = 0
+    states = QuantumAnnealingAnalytics._get_states(ising_model, energy_levels, n = n)
+    @test states == [0, 1, 2, 3]
 end


### PR DESCRIPTION
@ccoffrin I added filtering to all of the plotting functions except for the dwisc ones, since there seemed to be a lot of edge cases and I wasn't sure if it made a lot of sense to add to these since potentially there could be missing states.  It should be doable to add, but it might require a different approach to make sure that there are no issues if someone fed in an output for a large run on actual hardware (the current method would try to compute all of the energy levels, which would fail and I think people should be able to pass large systems without the plotting functions breaking down)