### PR TITLE
Add functionality to plot ising model graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ repo = "https://github.com/lanl-ansi/QuantumAnnealingAnalytics.jl"
 version = "0.2.0"
 
 [deps]
+GraphRecipes = "bd48cda9-67a9-57be-86fa-5b3c104eda73"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -12,9 +13,9 @@ QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-QuantumAnnealing = "~0.2"
-Plots = "~1, ~0.29"
 JSON = "~0.21, ~0.20, ~0.19, ~0.18"
+Plots = "~1, ~0.29"
+QuantumAnnealing = "~0.2"
 julia = "1.6"
 
 [extras]
@@ -22,4 +23,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-

--- a/src/QuantumAnnealingAnalytics.jl
+++ b/src/QuantumAnnealingAnalytics.jl
@@ -2,6 +2,7 @@ module QuantumAnnealingAnalytics
     import LinearAlgebra
     import Plots
     import Plots.Measures
+    import GraphRecipes
     import QuantumAnnealing
     import JSON
     const _QA = QuantumAnnealing

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -250,3 +250,41 @@ function plot_hamiltonian_energy_spectrum(hamiltonian::Function; s_range = (0,1)
     return plt
 end
 
+function plot_ising_model(ising_model; color_nodes=true, curves=false, nodeshape=:circle, kwargs...)
+    n = _QA._check_ising_model_ids(ising_model)
+    edges = fill(0, (n,n))
+    nodes = fill(0.0, n)
+    edge_labels = Dict()
+    for (k,v) in ising_model
+        if length(k) == 1
+            nodes[k[1]] = v
+        elseif length(k) == 2
+            edge_labels[k] = v
+            edges[k[1],k[2]] = 1
+            edges[k[2],k[1]] = 1
+        else
+            @warn("cannot display qubit couplings of more than two qubits, omitting coupling")
+        end
+    end
+    nodecolor = 1
+    if color_nodes
+        color_options = Plots.palette([:blue, :white, :red], 21)
+        color_choices = collect(color_options)
+        for (i,node) in enumerate(nodes)
+            color_val = round(node,digits=1)
+            if color_val < -1
+                color_val = -1
+            elseif color_val > 1
+                color_val = 1
+            end
+            color_index = round(Int64, ((color_val+1) * 10)+1)
+            color_choices[i] = color_options[color_index]
+        end
+        nodecolor = color_choices
+    end
+    if length(edge_labels) == 0
+        error("GraphRecipes.jl cannot currently take graphs without edges, so the ising model must have at least one nonzero coupling")
+    end
+    plt = GraphRecipes.graphplot(edges; nodecolor=nodecolor, names=nodes, curves=curves, edge_label=edge_labels, nodeshape=nodeshape, kwargs...)
+    return plt
+end

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -576,3 +576,30 @@ end
         @test true
     end
 end
+
+@testset "plotting ising model graphs" begin
+    ising_model = Dict((1,2) => 1)
+    @testset "no fields, one coupling" begin
+        plt = plot_ising_model(ising_model, color_nodes=false)
+        @test true
+        plt = plot_ising_model(ising_model)
+        @test true
+    end
+
+    ising_model = Dict((1,) => 1.1, (2,) => -0.4, (1,2) => -1.1)
+    @testset "with fields, one coupling" begin
+        plt = plot_ising_model(ising_model, color_nodes=false)
+        @test true
+        plt = plot_ising_model(ising_model)
+        @test true
+    end
+
+    ising_model = Dict((1,2) => 1, (1,2,3) => 1)
+    @testset "no fields, one two qubit coupling, one three qubit coupling" begin
+        plt = plot_ising_model(ising_model, color_nodes=false)
+        @test true
+        plt = plot_ising_model(ising_model)
+        @test true
+    end
+
+end


### PR DESCRIPTION
@ccoffrin it should be noted that there is some rather weird behavior due to GraphRecipes.jl.  I've looked in the issues section for the repository and some of the issues seem to have been existing for a few years.  I am not sure whether it makes sense to include this in the repository, simply due to how weird GR.jl is.  I will outline a few examples of what I am talking about below, and you can play with the function to see if you think it is worth adding.

The first and most readily found issue is that you cannot plot a single node, as would be seen by trying to execute the following code:
```
using GraphRecipes, Plots

g = fill(1.0, (1,1))
graphplot(g)
```

in a similar vein, but perhaps more severe, if you provide an adjacency matrix with nodes with no edges (all edges have weight 0), depending on which position the node is in the adjacency matrix.  For example the following code will produce the desired behavior (a graph with three vertices and one edge):

```
using GraphRecipes, Plots

g = [0 0 1; 0 0 0; 1 0 0]
graphplot(g)
```

while trying to plot the following isomorphic adjacency matrix will only plot a graph with two vertices and one edge:

```
using GraphRecipes, Plots

g = [0 1 0; 1 0 0; 0 0 0]
graphplot(g)
```

If you were to be so foolish as to only try to plot the identity (or any graph with all zero off diagonal elements), you will get an empty plot.

```
using GraphRecipes, Plots

g = [1 0 0; 0 1 0; 0 0 1]
graphplot(g)
```

That being said, we are able to get adequate functionality for most of the cases which we actually consider, like the two_qubit_model and the katzgraber model.  It might be possible to make a workaround for our edge cases, but at that point we might as well just make a pull request on the GraphRecipes.jl repository.